### PR TITLE
Language Frontend

### DIFF
--- a/S.A.M/Areas/ControlPanel/Controllers/LanguageController.cs
+++ b/S.A.M/Areas/ControlPanel/Controllers/LanguageController.cs
@@ -1,0 +1,89 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+using S.A.M.Data.Repositories.Languages;
+using S.A.M.Models.Language;
+
+namespace S.A.M.Areas.ControlPanel.Controllers;
+
+public class LanguageController : ControlPanelBaseController
+{
+    private readonly ILogger<LanguageController> _logger;
+    private readonly ILanguageRepository _languageRepository;
+    private readonly IMapper _mapper;
+    public LanguageController(ILogger<LanguageController> logger, ILanguageRepository languageRepository, IMapper mapper)
+    {
+        _logger = logger;
+        _languageRepository = languageRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        try
+        {
+            var languageEntities = await _languageRepository.GetAllLanguagesAsync();
+
+            return View(_mapper.Map<List<LanguageModel>>(languageEntities));
+        }
+        catch (Exception exp)
+        {
+
+            throw;
+        }
+    }
+
+    [HttpGet]
+    [Route("sam/api/[controller]/[action]")]
+    public async Task<IActionResult> ChangeDefaultLanguage(byte id)
+    {
+        try
+        {
+            var changed = await _languageRepository.ChangeDefaultLanguageAsync(id);
+
+            if (!changed)
+            {
+                return BadRequest(new { success = false, message = "Failed to change the default language." });
+            }
+            else
+            {
+                return Ok(new { success = true, message = "Default language changed successfully." });
+            }
+
+        }
+        catch (Exception exp)
+        {
+            return BadRequest(new { success = false, message = "An error occurred while changing the default language.", error = exp.Message });
+        }
+    }
+
+    [HttpGet]
+    [Route("sam/api/[controller]/[action]")]
+    public async Task<IActionResult> ChangeLanguageActivationStatus(byte id)
+    {
+        try
+        {
+            var changed = await _languageRepository.ChangeLanguageActivationStatusAsync(id);
+            if (changed == null)
+            {
+                return BadRequest(new { success = false, message = "Failed to change the language activation status." });
+            }
+            else
+            {
+                return Ok(new { success = true, message = "Language activation status changed successfully.", active = changed.Active });
+            }
+
+        }
+        catch (InvalidOperationException invalidOperationEx)
+        {
+            _logger.LogError(invalidOperationEx, "Error changing language activation status");
+            return BadRequest(new { success = false, message = "يجب أن تكون هناك لغة واحدة نشطة على الأقل.", error = invalidOperationEx.Message });
+        }
+        catch (Exception exp)
+        {
+            _logger.LogError(exp, "Error changing language activation status");
+            return BadRequest(new { success = false, message = "An error occurred while changing the default language.", error = exp.Message });
+        }
+    }
+
+
+}

--- a/S.A.M/Areas/ControlPanel/Views/Account/Login.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/Account/Login.cshtml
@@ -1,5 +1,6 @@
 ﻿@{
-     ViewData["Title"] = "Login";
+    Layout = null; 
+    ViewData["Title"] = "Login";
     // var rtl = System.Threading.Thread.CurrentThread.CurrentUICulture.TextInfo.IsRightToLeft;
 }
 

--- a/S.A.M/Areas/ControlPanel/Views/ArticlesManagement/Index.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/ArticlesManagement/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@{
-    Layout = "~/Areas/ControlPanel/Views/Shared/_Layout.cshtml";
 }
 <!-- Articles Management Section -->
 <div id="content-section" class="content-section fade-in">

--- a/S.A.M/Areas/ControlPanel/Views/Dashboard/Index.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/Dashboard/Index.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    Layout = "~/Areas/ControlPanel/Views/Shared/_Layout.cshtml";
+    
 }
 <!-- Dashboard Section -->
 <div id="dashboard-section" class="content-section">

--- a/S.A.M/Areas/ControlPanel/Views/Language/Index.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/Language/Index.cshtml
@@ -1,0 +1,68 @@
+﻿@model List<LanguageModel>
+
+<!-- Categories  Management Section -->
+<div id="content-section" class="content-section fade-in">
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-2xl font-bold text-gray-800 dark:text-white" data-translate="languages_management">إدارة المحتوى</h2>
+        <button class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors">
+            <i class="fas fa-plus mr-2 rtl:mr-0 rtl:ml-2"></i><span data-translate="add_new_language">إضافة مقال جديد</span>
+        </button>
+    </div>
+
+    
+    <!-- Language Table -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+        <table class="w-full" id="language-table">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-6 py-3 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider" @* data-translate="title" *@>اللغة</th>
+                    <th class="px-6 py-3 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider" @* data-translate="category" *@>الكود</th>
+                    <th class="px-6 py-3 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider" @* data-translate="language" *@>نشط</th>
+                    <th class="px-6 py-3 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider" @* data-translate="status" *@>اللغة الأساسية</th>
+                    <th class="px-6 py-3 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider" @* data-translate="date" *@>تاريخ الإنشاء</th>
+                    <th class="px-6 py-3 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider" @* data-translate="date" *@>تاريخ التحديث</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                @foreach (var language in Model)
+                {
+                    <tr>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm font-medium text-gray-900 dark:text-white" @* data-translate="democratic_reforms_syria" *@>@language.Name</div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm font-medium text-gray-900 dark:text-white" @* data-translate="democratic_reforms_syria" *@>@language.Code</div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white language-activation-status" @* data-translate="arabic" *@>
+                            @if (language.Active)
+                            {
+                                <a id="change-activation-status-@language.Id" onclick="LanguageIndex.changeActivationStatus(@language.Id, '@language.Name')" href="javascript:void(0);"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800" data-translate="record_active">نشط</span></a>
+                            }
+                            else
+                            {
+                                <a id="change-activation-status-@language.Id" onclick="LanguageIndex.changeActivationStatus(@language.Id, '@language.Name')" href="javascript:void(0);"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800" data-translate="record_inactive">متوقف</span></a>
+                            }
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap default-language">
+                            @if (language.Default)
+                            {
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800" data-translate="record_default" data-id="@language.Id">أساسي</span>
+                            }
+                            else
+                            {
+                                <a id="change-default-language-@language.Id" onclick="LanguageIndex.changeDefaultLanguage(@language.Id, '@language.Name')" href="javascript:void(0);"><span class="px-2 inline-flex text-xs leading0-5 font-semibold rounded-full bg-gray-100 text-black-800" data-translate="record_not_default">غير أساسي</span></a>
+                            }
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">@language.CreatedAt</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">@Html.Raw(DateTime.MinValue ==  language.UpdatedAt ? "لم يتم التحديث" : language.UpdatedAt) </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/common/tailwind.modal.js"></script>
+    <script src="~/js/controlpanel/language.index.js"></script>
+}

--- a/S.A.M/Areas/ControlPanel/Views/Shared/_Layout.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/Shared/_Layout.cshtml
@@ -44,7 +44,7 @@
             <nav class="mt-6">
                 <div class="px-6 mb-4">
                     <h3 class="text-xs uppercase text-gray-400 font-semibold" data-translate="main">Main</h3>
-                </div>
+                </div>/
                 <a href="~/ControlPanel/Dashboard/Index" class="nav-item flex items-center px-6 py-3 text-gray-300 hover:bg-sidebar-hover hover:text-white transition-colors active" data-section="dashboard">
                     <i class="fas fa-tachometer-alt w-5"></i>
                     <span class="ml-3 rtl:ml-0 rtl:mr-3" data-translate="dashboard">Dashboard</span>
@@ -105,7 +105,7 @@
                 <div class="px-6 mb-4 mt-8">
                     <h3 class="text-xs uppercase text-gray-400 font-semibold" data-translate="settings">Settings</h3>
                 </div>
-                <a href="#" class="nav-item flex items-center px-6 py-3 text-gray-300 hover:bg-sidebar-hover hover:text-white transition-colors" data-section="languages">
+                <a href="~/ControlPanel/Language/Index" class="nav-item flex items-center px-6 py-3 text-gray-300 hover:bg-sidebar-hover hover:text-white transition-colors" data-section="languages">
                     <i class="fas fa-globe w-5"></i>
                     <span class="ml-3 rtl:ml-0 rtl:mr-3" data-translate="languages">Languages</span>
                 </a>

--- a/S.A.M/Areas/ControlPanel/Views/_ViewImports.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+﻿@using S.A.M
+@using S.A.M.Models
+@using S.A.M.Models.Language
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/S.A.M/Areas/ControlPanel/Views/_ViewStart.cshtml
+++ b/S.A.M/Areas/ControlPanel/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "~/Areas/ControlPanel/Views/Shared/_Layout.cshtml";
+}

--- a/S.A.M/Data/Repositories/Languages/ILanguageRepository.cs
+++ b/S.A.M/Data/Repositories/Languages/ILanguageRepository.cs
@@ -10,4 +10,7 @@ public interface ILanguageRepository
     Task<Language> AddLanguageAsync(Language language);
     Task<Language> UpdateLanguageAsync(Language language);
     Task<bool> DeleteLanguageAsync(byte id);
+
+    Task<bool> ChangeDefaultLanguageAsync(byte id);
+    Task<Language> ChangeLanguageActivationStatusAsync(byte id);
 }

--- a/S.A.M/Helper/AutoMapperProfile.cs
+++ b/S.A.M/Helper/AutoMapperProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace S.A.M.Helper;
+
+public class AutoMapperProfile : Profile
+{
+    public AutoMapperProfile()
+    {
+        CreateMap<S.A.M.Models.Language.LanguageModel, S.A.M.Data.Entities.Language>();
+        CreateMap<S.A.M.Data.Entities.Language, S.A.M.Models.Language.LanguageModel>();
+    }
+}

--- a/S.A.M/Helper/ProgramHelper/ServiceConfigure.cs
+++ b/S.A.M/Helper/ProgramHelper/ServiceConfigure.cs
@@ -26,6 +26,8 @@ public static class ServiceConfigure
         builder.Services.AddHostedService<QueuedHostedService>();
         builder.Services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
 
+        builder.Services.AddAutoMapper(typeof(AutoMapperProfile));
+
         builder.Services.AddHttpContextAccessor();
         builder.Services.AddScoped<IUserInfoService, UserInfoService>();
 

--- a/S.A.M/Models/Language/LanguageModel.cs
+++ b/S.A.M/Models/Language/LanguageModel.cs
@@ -1,0 +1,12 @@
+﻿namespace S.A.M.Models.Language;
+
+public class LanguageModel
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public bool Active { get; set; }
+    public bool Default { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/S.A.M/Program.cs
+++ b/S.A.M/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddMvc()
 
 
 
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/S.A.M/S.A.M.csproj
+++ b/S.A.M/S.A.M.csproj
@@ -24,6 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.LinkedIn" Version="9.4.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.3.0" />

--- a/S.A.M/wwwroot/js/common/tailwind.modal.js
+++ b/S.A.M/wwwroot/js/common/tailwind.modal.js
@@ -1,0 +1,195 @@
+﻿class Modal {
+    constructor({ title = "", content = "", status = "info", size = "md", buttons = [] }) {
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.size = size;
+        this.buttons = buttons;
+        this.modalElement = null;
+        this.focusableEls = [];
+        this.firstFocusEl = null;
+        this.lastFocusEl = null;
+        this.handleKeydown = this.#handleKeydown.bind(this);
+    }
+
+    #getSizeClass() {
+        return {
+            sm: "max-w-sm",
+            md: "max-w-md",
+            lg: "max-w-xl",
+            xl: "max-w-2xl"
+        }[this.size] || "max-w-md";
+    }
+
+    #getStatusIcon() {
+        const icons = {
+            success: '<i class="fa-solid fa-circle-check text-green-600 text-xl"></i>'/*`<svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>`*/,
+            danger: '<i class="fa-solid fa-circle-exclamation text-red-600 text-xl"></i>'/*`<svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>`*/,
+            warning: '<i class="fa-solid fa-triangle-exclamation text-yellow-600 text-xl"></i>'/*`<svg class="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M4.93 4.93l14.14 14.14M4.93 19.07l14.14-14.14" /></svg>`*/,
+            info:  '<i class="fa-solid fa-circle-info text-blue-600 text-xl"></i>'/*`<svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" /></svg>`*/
+        };
+        return icons[this.status] || icons.info;
+    }
+
+    #trapFocus(e) {
+        if (e.key !== 'Tab') return;
+
+        if (e.shiftKey) {
+            if (document.activeElement === this.firstFocusEl) {
+                e.preventDefault();
+                this.lastFocusEl.focus();
+            }
+        } else {
+            if (document.activeElement === this.lastFocusEl) {
+                e.preventDefault();
+                this.firstFocusEl.focus();
+            }
+        }
+    }
+
+    #handleKeydown(e) {
+        if (e.key === "Escape") this.close("esc");
+        this.#trapFocus(e);
+    }
+
+    show() {
+        document.body.classList.add("modal-open");
+
+        this.modalElement = document.createElement("div");
+        this.modalElement.className = "fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50";
+
+        const modalBox = document.createElement("div");
+        modalBox.className = `bg-white p-6 rounded-xl shadow-xl w-full ${this.#getSizeClass()} relative modal-enter`;
+        modalBox.setAttribute("role", "dialog");
+        modalBox.setAttribute("aria-modal", "true");
+
+        modalBox.innerHTML = `
+          <button class="absolute top-2 right-2 text-gray-400 hover:text-gray-700" id="closeBtn" aria-label="Close">✕</button>
+          <div class="flex items-center gap-2 mb-4 mt-4">${this.#getStatusIcon()}<h2 class="text-xl font-semibold">${this.title}</h2></div>
+          <div class="modal-content mb-4"></div>
+          <div class="modal-buttons flex justify-end gap-2"></div>
+        `;
+
+        const contentContainer = modalBox.querySelector(".modal-content");
+        if (typeof this.content === "string") {
+            contentContainer.innerHTML = this.content;
+        } else {
+            contentContainer.appendChild(this.content);
+        }
+
+        const buttonsContainer = modalBox.querySelector(".modal-buttons");
+        this.buttons.forEach(({ label, className = "", onClick }) => {
+            const btn = document.createElement("button");
+            btn.textContent = label;
+            btn.className = `px-4 py-2 rounded ${className}`;
+            btn.onclick = () => {
+                if (typeof onClick === "function") onClick(label);
+                this.close(label);
+            };
+            buttonsContainer.appendChild(btn);
+        });
+
+        this.modalElement.appendChild(modalBox);
+        document.body.appendChild(this.modalElement);
+        setTimeout(() => modalBox.classList.add("modal-enter-active"), 10);
+
+        // Focus trap setup
+        this.focusableEls = modalBox.querySelectorAll('button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])');
+        if (this.focusableEls.length > 0) {
+            this.firstFocusEl = this.focusableEls[0];
+            this.lastFocusEl = this.focusableEls[this.focusableEls.length - 1];
+            this.firstFocusEl.focus();
+        }
+
+        document.addEventListener("keydown", this.handleKeydown);
+        this.modalElement.querySelector("#closeBtn").onclick = () => this.close("close");
+    }
+
+    close(actionType) {
+        const modalBox = this.modalElement.querySelector("div");
+        modalBox.classList.remove("modal-enter-active");
+        modalBox.classList.add("modal-leave", "modal-leave-active");
+
+        setTimeout(() => {
+            document.body.removeChild(this.modalElement);
+            document.body.classList.remove("modal-open");
+            document.removeEventListener("keydown", this.handleKeydown);
+            console.log("Modal closed with action:", actionType);
+        }, 200);
+    }
+}
+
+//class Modal {
+//    constructor({ title = "", content = "", status = "info", buttons = [] }) {
+//        this.title = title;
+//        this.content = content; // Can be a string or HTMLElement
+//        this.status = status;
+//        this.buttons = buttons; // Array of { label, class, onClick }
+//        this.modalElement = null;
+//    }
+
+//    #getStatusIcon() {
+//        const icons = {
+//            success: `<svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>`,
+//            danger: `<svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>`,
+//            warning: `<svg class="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M4.93 4.93l14.14 14.14M4.93 19.07l14.14-14.14" /></svg>`,
+//            info: `<svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" /></svg>`
+//        };
+//        return icons[this.status] || icons.info;
+//    }
+
+//    show() {
+//        this.modalElement = document.createElement("div");
+//        this.modalElement.className = "fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50";
+
+//        const modalBox = document.createElement("div");
+//        modalBox.className = "bg-white p-6 rounded-xl shadow-xl w-full max-w-md relative modal-enter";
+
+//        // Icon + Title
+//        modalBox.innerHTML = `
+//          <button class="absolute top-2 right-2 text-gray-400 hover:text-gray-700" id="closeBtn">✕</button>
+//          <div class="flex items-center gap-2 mb-4">${this.#getStatusIcon()}<h2 class="text-xl font-semibold">${this.title}</h2></div>
+//          <div class="modal-content mb-4"></div>
+//          <div class="modal-buttons flex justify-end gap-2"></div>
+//        `;
+
+//        // Insert content
+//        const contentContainer = modalBox.querySelector(".modal-content");
+//        if (typeof this.content === "string") {
+//            contentContainer.innerHTML = this.content;
+//        } else if (this.content instanceof HTMLElement) {
+//            contentContainer.appendChild(this.content);
+//        }
+
+//        // Insert buttons
+//        const buttonsContainer = modalBox.querySelector(".modal-buttons");
+//        this.buttons.forEach(({ label, className = "", onClick }) => {
+//            const btn = document.createElement("button");
+//            btn.textContent = label;
+//            btn.className = `px-4 py-2 rounded ${className}`;
+//            btn.onclick = () => {
+//                if (typeof onClick === "function") onClick();
+//                this.close();
+//            };
+//            buttonsContainer.appendChild(btn);
+//        });
+
+//        // Append and animate
+//        this.modalElement.appendChild(modalBox);
+//        document.body.appendChild(this.modalElement);
+//        setTimeout(() => modalBox.classList.add("modal-enter-active"), 10);
+
+//        // Close button
+//        this.modalElement.querySelector("#closeBtn").onclick = () => this.close();
+//    }
+
+//    close() {
+//        const modalBox = this.modalElement.querySelector("div");
+//        modalBox.classList.remove("modal-enter-active");
+//        modalBox.classList.add("modal-leave", "modal-leave-active");
+
+//        setTimeout(() => {
+//            document.body.removeChild(this.modalElement);
+//        }, 200);
+//    }
+//}

--- a/S.A.M/wwwroot/js/controlpanel/language.index.js
+++ b/S.A.M/wwwroot/js/controlpanel/language.index.js
@@ -1,0 +1,194 @@
+﻿"use strict";
+
+var LanguageIndex = function () {
+
+
+	let languageChangeActivityStatusTitle = 'تغيير حالة اللغة';
+
+	let veryfingChangeDefaultLanget = function (languageId, languageName) {
+
+		let modal = new Modal({
+			title: "تغيير اللغة الأساسية",
+			content: 'هل تريد تغيير اللغة الأساسية للموقع, لتصبح اللغة ' + languageName,
+			status: "info",
+			size: "lg",
+			buttons: [
+				{
+					label: "إلغاء الأمر",
+					className: "bg-gray-300 hover:bg-gray-400",
+				},
+				{
+					label: "نعم",
+					className: "bg-blue-600 text-white hover:bg-blue-700",
+					onClick: () => {
+						changeDefaultLanguage(languageId, languageName);
+					}
+				}
+			]
+		});
+		modal.show();
+	};
+	let changeDefaultLanguage = function (languageId, languageName) {		
+		$.ajax({
+			type: "GET",
+			url: '/sam/api/Language/ChangeDefaultLanguage?id=' + languageId + '',
+			dataType: "json",
+			success: function (data, callback) {
+				applyChangeDefaultLanguage(languageId, languageName, data);
+			},
+			error: function (xhr, status, error) {
+				applyChangeDefaultLanguage(languageId, languageName, xhr.responseJSON);
+			}
+		});
+		
+	}
+	let applyChangeDefaultLanguage = function (languageId, languageName, result) {
+		if (result.success) {
+			$('.default-language').each(function (i, e) {
+				let anchor = $(e).find('a');
+				if (anchor != undefined && anchor.length > 0) {
+					if (anchor.attr('id') == 'change-default-language-' + languageId) {
+						$(e).html('<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800" data-translate="record_default" data-id="' + languageId + '">أساسي</span>');
+					}
+				}
+				else {
+					let span = $(e).find('span');
+					if (span != undefined) {
+						$(e).html('<a id="change-default-language-' + span.attr('data-id') + '" onclick="LanguageIndex.changeDefaultLanguage(' + span.attr('data-id') + ', ' + '\'' + languageName + '\''+ ')" href="javascript:void(0);"><span class="px-2 inline-flex text-xs leading0-5 font-semibold rounded-full bg-gray-100 text-blacl-800" data-translate="record_not_default">غير أساسي</span></a>');
+					}
+				}
+
+			});
+
+			let modal = new Modal({
+				title: "تغيير اللغة الأساسية",
+				content: '<div>نجحت عملية تغيير اللغة الأساسية </div><p class="text-green-800 text-xl">' + languageName + '</p>',
+				status: "success",
+				size: "lg",
+				buttons: [
+					{
+						label: "حسناً",
+						className: "bg-green-600 text-white hover:bg-green-700",
+					}
+				]
+			});
+			modal.show();
+		}
+		else {
+			let modal = new Modal({
+				title: "تغيير اللغة الأساسية",
+				content: '<div>فشلت عملية تغيير اللغة بسبب خطأ فني : </div><p class="text-red-800 text-xl">' + result.message + '</p>',
+				status: "danger",
+				size: "lg",
+				buttons: [
+					{
+						label: "حسناً",
+						className: "bg-gray-300 hover:bg-gray-400",
+					}
+				]
+			});
+			modal.show();
+		}
+	};
+
+
+	let veryfingChangeActivationStatus = function (languageId, languageName) {
+
+		let modal = new Modal({
+			title: languageChangeActivityStatusTitle,
+			content: 'هل تريد تغيير حالة اللغة {' + languageName + '}المستخدمة في الموقع,  لتصبح غير نشطة',
+			status: "warning",
+			size: "lg",
+			buttons: [
+				{
+					label: "إلغاء الأمر",
+					className: "bg-gray-300 hover:bg-gray-400",
+				},
+				{
+					label: "نعم",
+					className: "bg-yellow-600 text-white hover:bg-yellow-700",
+					onClick: () => {
+						changeLanguageActivationStatus(languageId, languageName);
+					}
+				}
+			]
+		});
+		modal.show();
+	};
+	let changeLanguageActivationStatus = function (languageId, languageName) {
+		$.ajax({
+			type: "GET",
+			url: '/sam/api/Language/ChangeLanguageActivationStatus?id=' + languageId + '',
+			dataType: "json",
+			success: function (data, callback) {
+				applyChangeLanguageActivationStatus(languageId, languageName, data);
+			},
+			error: function (xhr, status, error) {
+				applyChangeLanguageActivationStatus(languageId, languageName, xhr.responseJSON);
+			}
+		});
+
+	}
+	let applyChangeLanguageActivationStatus = function (languageId, languageName, result) {
+		if (result.success) {
+			let anchor = $('.language-activation-status').find('a#change-activation-status-' + languageId);
+
+			if (anchor != undefined && anchor.length > 0) {
+				if (result.active) {
+					$(anchor).parent().html('<a id="change-activation-status-' + languageId + '" onclick="LanguageIndex.changeActivationStatus(' + languageId + ', ' + '\'' + languageName + '\'' + ')" href="javascript:void(0);"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800" data-translate="record_active">نشط</span></a>');
+				}
+				else {
+					$(anchor).parent().html('<a id="change-activation-status-' + languageId + '" onclick="LanguageIndex.changeActivationStatus(' + languageId + ', ' + '\'' + languageName + '\'' + ')" href="javascript:void(0);"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-black-800" data-translate="record_inactive">متوقف</span></a>');
+				}
+			}
+
+			let modal = new Modal({
+				title: languageChangeActivityStatusTitle,
+				content: '<div>نجحت عملية تغيير حالة اللغة </div><p class="text-green-800 text-xl">' + languageName + '</p>',
+				status: "success",
+				size: "lg",
+				buttons: [
+					{
+						label: "حسناً",
+						className: "bg-green-600 text-white hover:bg-green-700",
+					}
+				]
+			});
+			modal.show();
+		}
+		else {
+			let modal = new Modal({
+				title: languageChangeActivityStatusTitle,
+				content: '<div>فشلت عملية تغيير اللغة بسبب خطأ فني : </div><p class="text-red-800 text-xl">' + result.message + '</p>',
+				status: "danger",
+				size: "lg",
+				buttons: [
+					{
+						label: "حسناً",
+						className: "bg-gray-300 hover:bg-gray-400",
+					}
+				]
+			});
+			modal.show();
+		}
+	};
+			
+
+
+	return {
+		init: function () {
+			
+		},
+		changeDefaultLanguage: function (languageId, languageName) {
+			veryfingChangeDefaultLanget(languageId, languageName)
+		},
+		changeActivationStatus: function (languageId, languageName) {
+			veryfingChangeActivationStatus(languageId, languageName)
+		}
+
+	};
+
+}();
+$(document).ready(function () {
+	
+});

--- a/S.A.M/wwwroot/js/controlpanel/site.js
+++ b/S.A.M/wwwroot/js/controlpanel/site.js
@@ -11,6 +11,7 @@
                 main: "Main",
                 dashboard: "Dashboard",
                 articles_management: "Articles Management",
+                languages_management: "Languages Management",
                 media_library: "Media Library",
                 pages_management : "Pages Management",
                 user_management: "User Management",
@@ -72,6 +73,7 @@
                 
                 // Content Management
                 add_new_article: "Add New Article",
+                add_new_language : "Add New Language",
                 all_categories: "All Categories",
                 politics: "Politics",
                 education: "Education",
@@ -83,6 +85,10 @@
                 french: "French",
                 all_status: "All Status",
                 published: "Published",
+                record_active: "Active",
+                record_inactive: "Inactive",
+                record_default: "Default",
+                record_not_default: "Not Default",
                 draft: "Draft",
                 pending: "Pending",
                 search_articles: "Search articles...",
@@ -163,6 +169,7 @@
                 main: "الرئيسية",
                 dashboard: "لوحة المعلومات",
                 articles_management: "إدارة المقالات",
+                languages_management : "إدارة اللغات",
                 media_library: "مكتبة الوسائط",
                 pages_management: "إدارة الصفحات",
                 user_management: "إدارة المستخدمين",
@@ -224,6 +231,7 @@
                 
                 // Content Management
                 add_new_article: "إضافة مقال جديد",
+                add_new_language: "إضافة لغة جديدة",
                 all_categories: "جميع الفئات",
                 politics: "السياسة",
                 education: "التعليم",
@@ -235,6 +243,10 @@
                 french: "الفرنسية",
                 all_status: "جميع الحالات",
                 published: "منشور",
+                record_active: "نشط",
+                record_inactive: "متوقف",
+                record_default: "أساسي",
+                record_not_default: "غير أساسي",
                 draft: "مسودة",
                 pending: "في الانتظار",
                 search_articles: "البحث في المقالات...",


### PR DESCRIPTION
### Add:
- `LanguageController` in `ControlPanl` Area.
- `Index` page for `LanguageController`.
- `LanguageModel` class to work as Dto.
- `language.index.js` to handel `Index` page functionalities.
- `tailwind.modal.js` modal component created by `ChatGPT` URL:  https://chatgpt.com/share/68616d27-8dd4-8005-9140-c46059824f78
- `_ViewImports.cshtml` to control imported models that used in views.
- `_ViewStart.cshtml`  to control the `ControlPanel` Area primary layout. ### Packages:
- `AutoMapper`
- `AutoMapper.Extensions.Microsoft.DependencyInjection`